### PR TITLE
Skip building index for non-read tables

### DIFF
--- a/src/main/java/org/elasql/bench/server/param/tpcc/TpccSchemaBuilderProcParamHelper.java
+++ b/src/main/java/org/elasql/bench/server/param/tpcc/TpccSchemaBuilderProcParamHelper.java
@@ -60,15 +60,23 @@ public class TpccSchemaBuilderProcParamHelper extends StoredProcedureParamHelper
 			"CREATE INDEX idx_district ON district (d_w_id, d_id)",
 //			"CREATE INDEX idx_customer ON customer (c_id)",
 			"CREATE INDEX idx_customer ON customer (c_w_id, c_d_id, c_id)",
+
+			// TPCC won't read history
 //			"CREATE INDEX idx_history ON history (h_c_id)",
-			"CREATE INDEX idx_history ON history (h_c_w_id, h_c_d_id, h_c_id, h_id)",
+//			"CREATE INDEX idx_history ON history (h_c_w_id, h_c_d_id, h_c_id, h_id)",
+
+			// TPCC won't read orders 
 //			"CREATE INDEX idx_order ON orders (o_id)",
-			"CREATE INDEX idx_order ON orders (o_w_id, o_d_id, o_id)",
+//			"CREATE INDEX idx_order ON orders (o_w_id, o_d_id, o_id)",
+
+			// TPCC won't read new_order
 //			"CREATE INDEX idx_new_order ON new_order (no_o_id)",
-			"CREATE INDEX idx_new_order ON new_order (no_w_id, no_d_id, no_o_id)",
+//			"CREATE INDEX idx_new_order ON new_order (no_w_id, no_d_id, no_o_id)",
+
+			// TPCC won't read order_line
 //			"CREATE INDEX idx_order_line ON order_line (ol_o_id)",
-			"CREATE INDEX idx_order_line ON order_line (ol_w_id, ol_d_id, ol_o_id, ol_number)",
-//			"CREATE INDEX idx_stock ON stock (s_i_id)",
+//			"CREATE INDEX idx_order_line ON order_line (ol_w_id, ol_d_id, ol_o_id, ol_number)",
+			
 			"CREATE INDEX idx_stock ON stock (s_w_id, s_i_id)",
 			"CREATE INDEX idx_item ON item (i_id)" };
 


### PR DESCRIPTION
TPCC won't read tables such as history, orders, new_order, and orderlines.
We could skip building index for these four tables to enhance the performance.