### PR TITLE
Update the dependencies to ElaSQL and VanillaBench

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,12 @@
 		<dependency>
 			<groupId>org.vanilladb</groupId>
 			<artifactId>bench</artifactId>
-			<version>0.4.1</version>
+			<version>0.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.elasql</groupId>
 			<artifactId>elasql</artifactId>
-			<version>0.3.0</version>
+			<version>0.3.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
As the title,

update the dependencies to ElaSQL and VanillaBench:

- ElaSQL: `0.4.1` -> `0.4.2`
- VanillaBench: `0.3.0` -> `0.3.1`